### PR TITLE
Access violation in libbfio_memory_range_read() during memory_copy()

### DIFF
--- a/libbfio/libbfio_memory_range.c
+++ b/libbfio/libbfio_memory_range.c
@@ -642,7 +642,7 @@ ssize_t libbfio_memory_range_read(
 	if( memory_copy(
 	     buffer,
 	     &( memory_range_io_handle->range_start[ memory_range_io_handle->range_offset ] ),
-	     size ) == NULL )
+	     read_size ) == NULL )
 	{
 		libcerror_error_set(
 		 error,


### PR DESCRIPTION
Occurs when requested size is larger than size of range.

Was reproduced with the following piece of code:
```
    libbfio_handle_t *bfioHandleItem = 0;
    char buf[] = "hello world";
    char *outbuf = (char*)malloc(1024 * 1024);

    libbfio_memory_range_initialize(&bfioHandleItem, 0);
    libbfio_memory_range_set(bfioHandleItem, &buf[0], sizeof(buf), 0);

    libbfio_handle_open(bfioHandleItem, LIBBFIO_OPEN_READ, 0);

    libbfio_handle_read_buffer(bfioHandleItem, outbuf, 1024 * 1024, 0);
```