### PR TITLE
Drop bogus tests for memcpy() and memset().

### DIFF
--- a/tests/bfio_test_file.c
+++ b/tests/bfio_test_file.c
@@ -61,7 +61,6 @@ int bfio_test_file_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests = 3;
-	int number_of_memset_fail_tests = 1;
 	int test_number                 = 0;
 #endif
 
@@ -159,48 +158,6 @@ int bfio_test_file_initialize(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( handle != NULL )
-			{
-				libbfio_handle_free(
-				 &handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "handle",
-			 handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_file_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_file_initialize(
-		          &handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( handle != NULL )
 			{

--- a/tests/bfio_test_file_io_handle.c
+++ b/tests/bfio_test_file_io_handle.c
@@ -64,7 +64,6 @@ int bfio_test_file_io_handle_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests          = 2;
-	int number_of_memset_fail_tests          = 1;
 	int test_number                          = 0;
 #endif
 
@@ -186,48 +185,6 @@ int bfio_test_file_io_handle_initialize(
 			 &error );
 		}
 	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_file_io_handle_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_file_io_handle_initialize(
-		          &file_io_handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
-
-			if( file_io_handle != NULL )
-			{
-				libbfio_file_io_handle_free(
-				 &file_io_handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "file_io_handle",
-			 file_io_handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 	return( 1 );
@@ -300,10 +257,6 @@ int bfio_test_file_io_handle_clone(
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests                      = 3;
 	int test_number                                      = 0;
-
-#if defined( OPTIMIZATION_DISABLED )
-	int number_of_memcpy_fail_tests                      = 1;
-#endif
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 	/* Initialize test
@@ -524,51 +477,6 @@ int bfio_test_file_io_handle_clone(
 			 &error );
 		}
 	}
-#if defined( OPTIMIZATION_DISABLED )
-	for( test_number = 0;
-	     test_number < number_of_memcpy_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_file_io_handle_clone with memcpy failing
-		 */
-		bfio_test_memcpy_attempts_before_fail = test_number;
-
-		result = libbfio_file_io_handle_clone(
-		          &destination_file_io_handle,
-		          source_file_io_handle,
-		          &error );
-
-		if( bfio_test_memcpy_attempts_before_fail != -1 )
-		{
-			bfio_test_memcpy_attempts_before_fail = -1;
-
-			if( destination_file_io_handle != NULL )
-			{
-				libbfio_file_io_handle_free(
-				 &destination_file_io_handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "destination_file_io_handle",
-			 destination_file_io_handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-#endif /* defined( OPTIMIZATION_DISABLED ) */
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 	/* Clean up
@@ -1393,37 +1301,6 @@ int bfio_test_file_io_handle_set_name(
 		libcerror_error_free(
 		 &error );
 	}
-#if defined( OPTIMIZATION_DISABLED )
-
-	/* Test libbfio_file_io_handle_set_name with memcpy failing
-	 */
-	bfio_test_memcpy_attempts_before_fail = 0;
-
-	result = libbfio_file_io_handle_set_name(
-	          file_io_handle,
-	          "test",
-	          4,
-	          &error );
-
-	if( bfio_test_memcpy_attempts_before_fail != -1 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
-	}
-	else
-	{
-		BFIO_TEST_ASSERT_EQUAL_INT(
-		 "result",
-		 result,
-		 -1 );
-
-		BFIO_TEST_ASSERT_IS_NOT_NULL(
-		 "error",
-		 error );
-
-		libcerror_error_free(
-		 &error );
-	}
-#endif /* defined( OPTIMIZATION_DISABLED ) */
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 	/* Clean up
@@ -1806,37 +1683,6 @@ int bfio_test_file_io_handle_set_name_wide(
 		libcerror_error_free(
 		 &error );
 	}
-#if defined( OPTIMIZATION_DISABLED )
-
-	/* Test libbfio_file_io_handle_set_name_wide with memcpy failing
-	 */
-	bfio_test_memcpy_attempts_before_fail = 0;
-
-	result = libbfio_file_io_handle_set_name_wide(
-	          file_io_handle,
-	          L"test",
-	          4,
-	          &error );
-
-	if( bfio_test_memcpy_attempts_before_fail != -1 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
-	}
-	else
-	{
-		BFIO_TEST_ASSERT_EQUAL_INT(
-		 "result",
-		 result,
-		 -1 );
-
-		BFIO_TEST_ASSERT_IS_NOT_NULL(
-		 "error",
-		 error );
-
-		libcerror_error_free(
-		 &error );
-	}
-#endif /* defined( OPTIMIZATION_DISABLED ) */
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 	/* Clean up

--- a/tests/bfio_test_file_range.c
+++ b/tests/bfio_test_file_range.c
@@ -61,7 +61,6 @@ int bfio_test_file_range_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests = 2;
-	int number_of_memset_fail_tests = 1;
 	int test_number                 = 0;
 #endif
 
@@ -156,48 +155,6 @@ int bfio_test_file_range_initialize(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( handle != NULL )
-			{
-				libbfio_handle_free(
-				 &handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "handle",
-			 handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_file_range_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_file_range_initialize(
-		          &handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( handle != NULL )
 			{

--- a/tests/bfio_test_file_range_io_handle.c
+++ b/tests/bfio_test_file_range_io_handle.c
@@ -65,7 +65,6 @@ int bfio_test_file_range_io_handle_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests                      = 2;
-	int number_of_memset_fail_tests                      = 1;
 	int test_number                                      = 0;
 #endif
 
@@ -187,48 +186,6 @@ int bfio_test_file_range_io_handle_initialize(
 			 &error );
 		}
 	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_file_range_io_handle_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_file_range_io_handle_initialize(
-		          &file_range_io_handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
-
-			if( file_range_io_handle != NULL )
-			{
-				libbfio_file_range_io_handle_free(
-				 &file_range_io_handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "file_range_io_handle",
-			 file_range_io_handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 	return( 1 );
@@ -299,7 +256,6 @@ int bfio_test_file_range_io_handle_clone(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests                                  = 2;
-	int number_of_memset_fail_tests                                  = 1;
 	int test_number                                                  = 0;
 #endif
 
@@ -435,49 +391,6 @@ int bfio_test_file_range_io_handle_clone(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( destination_file_range_io_handle != NULL )
-			{
-				libbfio_file_range_io_handle_free(
-				 &destination_file_range_io_handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "destination_file_range_io_handle",
-			 destination_file_range_io_handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_file_range_io_handle_clone with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_file_range_io_handle_clone(
-		          &destination_file_range_io_handle,
-		          source_file_range_io_handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( destination_file_range_io_handle != NULL )
 			{

--- a/tests/bfio_test_handle.c
+++ b/tests/bfio_test_handle.c
@@ -210,7 +210,6 @@ int bfio_test_handle_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests = 3;
-	int number_of_memset_fail_tests = 1;
 	int test_number                 = 0;
 #endif
 
@@ -353,60 +352,6 @@ int bfio_test_handle_initialize(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( handle != NULL )
-			{
-				libbfio_handle_free(
-				 &handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "handle",
-			 handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_handle_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_handle_initialize(
-		          &handle,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          NULL,
-		          0,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( handle != NULL )
 			{
@@ -752,47 +697,6 @@ int bfio_test_handle_clone(
 		libcerror_error_free(
 		 &error );
 	}
-#if defined( OPTIMIZATION_DISABLED )
-
-	/* Test libbfio_handle_clone with memcpy failing
-	 */
-	bfio_test_memcpy_attempts_before_fail = 0;
-
-	result = libbfio_handle_clone(
-	          &destination_handle,
-	          source_handle,
-	          &error );
-
-	if( bfio_test_memcpy_attempts_before_fail != -1 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
-
-		if( destination_handle != NULL )
-		{
-			libbfio_handle_free(
-			 &destination_handle,
-			 NULL );
-		}
-	}
-	else
-	{
-		BFIO_TEST_ASSERT_EQUAL_INT(
-		 "result",
-		 result,
-		 -1 );
-
-		BFIO_TEST_ASSERT_IS_NULL(
-		 "destination_handle",
-		 destination_handle );
-
-		BFIO_TEST_ASSERT_IS_NOT_NULL(
-		 "error",
-		 error );
-
-		libcerror_error_free(
-		 &error );
-	}
-#endif /* defined( OPTIMIZATION_DISABLED ) */
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */
 
 #if defined( HAVE_BFIO_TEST_RWLOCK )

--- a/tests/bfio_test_memory.c
+++ b/tests/bfio_test_memory.c
@@ -36,13 +36,9 @@
 #if defined( HAVE_BFIO_TEST_MEMORY )
 
 static void *(*bfio_test_real_malloc)(size_t)                       = NULL;
-static void *(*bfio_test_real_memcpy)(void *, const void *, size_t) = NULL;
-static void *(*bfio_test_real_memset)(void *, int, size_t)          = NULL;
 static void *(*bfio_test_real_realloc)(void *, size_t)              = NULL;
 
 int bfio_test_malloc_attempts_before_fail                           = -1;
-int bfio_test_memcpy_attempts_before_fail                           = -1;
-int bfio_test_memset_attempts_before_fail                           = -1;
 int bfio_test_realloc_attempts_before_fail                          = -1;
 
 /* Custom malloc for testing memory error cases
@@ -71,72 +67,6 @@ void *malloc(
 		bfio_test_malloc_attempts_before_fail--;
 	}
 	ptr = bfio_test_real_malloc(
-	       size );
-
-	return( ptr );
-}
-
-/* Custom memcpy for testing memory error cases
- * Note this function might fail if compiled with optimation and as a shared libary
- * Returns a pointer to newly allocated data or NULL
- */
-void *memcpy(
-       void *destination,
-       const void *source,
-       size_t size )
-{
-	if( bfio_test_real_memcpy == NULL )
-	{
-		bfio_test_real_memcpy = dlsym(
-		                         RTLD_NEXT,
-		                         "memcpy" );
-	}
-	if( bfio_test_memcpy_attempts_before_fail == 0 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
-
-		return( NULL );
-	}
-	else if( bfio_test_memcpy_attempts_before_fail > 0 )
-	{
-		bfio_test_memcpy_attempts_before_fail--;
-	}
-	destination = bfio_test_real_memcpy(
-	               destination,
-	               source,
-	               size );
-
-	return( destination );
-}
-
-/* Custom memset for testing memory error cases
- * Note this function might fail if compiled with optimation and as a shared libary
- * Returns a pointer to newly allocated data or NULL
- */
-void *memset(
-       void *ptr,
-       int constant,
-       size_t size )
-{
-	if( bfio_test_real_memset == NULL )
-	{
-		bfio_test_real_memset = dlsym(
-		                         RTLD_NEXT,
-		                         "memset" );
-	}
-	if( bfio_test_memset_attempts_before_fail == 0 )
-	{
-		bfio_test_memset_attempts_before_fail = -1;
-
-		return( NULL );
-	}
-	else if( bfio_test_memset_attempts_before_fail > 0 )
-	{
-		bfio_test_memset_attempts_before_fail--;
-	}
-	ptr = bfio_test_real_memset(
-	       ptr,
-	       constant,
 	       size );
 
 	return( ptr );

--- a/tests/bfio_test_memory.h
+++ b/tests/bfio_test_memory.h
@@ -36,10 +36,6 @@ extern "C" {
 
 extern int bfio_test_malloc_attempts_before_fail;
 
-extern int bfio_test_memcpy_attempts_before_fail;
-
-extern int bfio_test_memset_attempts_before_fail;
-
 extern int bfio_test_realloc_attempts_before_fail;
 
 #endif /* defined( HAVE_BFIO_TEST_MEMORY ) */

--- a/tests/bfio_test_memory_range.c
+++ b/tests/bfio_test_memory_range.c
@@ -62,7 +62,6 @@ int bfio_test_memory_range_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests = 1;
-	int number_of_memset_fail_tests = 1;
 	int test_number                 = 0;
 #endif
 
@@ -157,48 +156,6 @@ int bfio_test_memory_range_initialize(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( handle != NULL )
-			{
-				libbfio_handle_free(
-				 &handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "handle",
-			 handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_memory_range_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_memory_range_initialize(
-		          &handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( handle != NULL )
 			{

--- a/tests/bfio_test_memory_range_io_handle.c
+++ b/tests/bfio_test_memory_range_io_handle.c
@@ -64,7 +64,6 @@ int bfio_test_memory_range_io_handle_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests                      = 2;
-	int number_of_memset_fail_tests                      = 1;
 	int test_number                                      = 0;
 #endif
 
@@ -159,48 +158,6 @@ int bfio_test_memory_range_io_handle_initialize(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( memory_range_io_handle != NULL )
-			{
-				libbfio_memory_range_io_handle_free(
-				 &memory_range_io_handle,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "memory_range_io_handle",
-			 memory_range_io_handle );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_memory_range_io_handle_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_memory_range_io_handle_initialize(
-		          &memory_range_io_handle,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( memory_range_io_handle != NULL )
 			{
@@ -424,45 +381,6 @@ int bfio_test_memory_range_io_handle_clone(
 	if( bfio_test_malloc_attempts_before_fail != -1 )
 	{
 		bfio_test_malloc_attempts_before_fail = -1;
-
-		if( destination_memory_range_io_handle != NULL )
-		{
-			libbfio_memory_range_io_handle_free(
-			 &destination_memory_range_io_handle,
-			 NULL );
-		}
-	}
-	else
-	{
-		BFIO_TEST_ASSERT_EQUAL_INT(
-		 "result",
-		 result,
-		 -1 );
-
-		BFIO_TEST_ASSERT_IS_NULL(
-		 "destination_memory_range_io_handle",
-		 destination_memory_range_io_handle );
-
-		BFIO_TEST_ASSERT_IS_NOT_NULL(
-		 "error",
-		 error );
-
-		libcerror_error_free(
-		 &error );
-	}
-
-	/* Test libbfio_memory_range_io_handle_clone with memcpy failing
-	 */
-	bfio_test_memcpy_attempts_before_fail = 0;
-
-	result = libbfio_memory_range_io_handle_clone(
-	          &destination_memory_range_io_handle,
-	          source_memory_range_io_handle,
-	          &error );
-
-	if( bfio_test_memcpy_attempts_before_fail != -1 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
 
 		if( destination_memory_range_io_handle != NULL )
 		{
@@ -1398,38 +1316,6 @@ int bfio_test_memory_range_io_handle_read_buffer(
 	libcerror_error_free(
 	 &error );
 
-#if defined( HAVE_BFIO_TEST_MEMORY ) && defined( OPTIMIZATION_DISABLED )
-
-	/* Test libbfio_memory_range_io_handle_read_buffer with memcpy failing
-	 */
-	bfio_test_memcpy_attempts_before_fail = 0;
-
-	read_count = libbfio_memory_range_io_handle_read_buffer(
-	              memory_range_io_handle,
-	              buffer,
-	              32,
-	              &error );
-
-	if( bfio_test_memcpy_attempts_before_fail != -1 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
-	}
-	else
-	{
-		BFIO_TEST_ASSERT_EQUAL_SSIZE(
-		 "read_count",
-		 read_count,
-		 (ssize_t) -1 );
-
-		BFIO_TEST_ASSERT_IS_NOT_NULL(
-		 "error",
-		 error );
-
-		libcerror_error_free(
-		 &error );
-	}
-#endif /* defined( HAVE_BFIO_TEST_MEMORY ) && defined( OPTIMIZATION_DISABLED ) */
-
 	/* Initialize test
 	 */
 	result = libbfio_memory_range_io_handle_initialize(
@@ -1698,38 +1584,6 @@ int bfio_test_memory_range_io_handle_write_buffer(
 
 	libcerror_error_free(
 	 &error );
-
-#if defined( HAVE_BFIO_TEST_MEMORY ) && defined( OPTIMIZATION_DISABLED )
-
-	/* Test libbfio_memory_range_io_handle_write_buffer with memcpy failing
-	 */
-	bfio_test_memcpy_attempts_before_fail = 0;
-
-	write_count = libbfio_memory_range_io_handle_write_buffer(
-	               memory_range_io_handle,
-	               buffer,
-	               32,
-	               &error );
-
-	if( bfio_test_memcpy_attempts_before_fail != -1 )
-	{
-		bfio_test_memcpy_attempts_before_fail = -1;
-	}
-	else
-	{
-		BFIO_TEST_ASSERT_EQUAL_SSIZE(
-		 "write_count",
-		 write_count,
-		 (ssize_t) -1 );
-
-		BFIO_TEST_ASSERT_IS_NOT_NULL(
-		 "error",
-		 error );
-
-		libcerror_error_free(
-		 &error );
-	}
-#endif /* defined( HAVE_BFIO_TEST_MEMORY ) && defined( OPTIMIZATION_DISABLED ) */
 
 	/* Initialize test
 	 */

--- a/tests/bfio_test_pool.c
+++ b/tests/bfio_test_pool.c
@@ -259,7 +259,6 @@ int bfio_test_pool_initialize(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests = 5;
-	int number_of_memset_fail_tests = 1;
 	int test_number                 = 0;
 #endif
 
@@ -398,50 +397,6 @@ int bfio_test_pool_initialize(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( pool != NULL )
-			{
-				libbfio_pool_free(
-				 &pool,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "pool",
-			 pool );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_pool_initialize with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_pool_initialize(
-		          &pool,
-		          0,
-		          LIBBFIO_POOL_UNLIMITED_NUMBER_OF_OPEN_HANDLES,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( pool != NULL )
 			{
@@ -625,7 +580,6 @@ int bfio_test_pool_clone(
 
 #if defined( HAVE_BFIO_TEST_MEMORY )
 	int number_of_malloc_fail_tests = 5;
-	int number_of_memset_fail_tests = 1;
 	int test_number                 = 0;
 #endif
 
@@ -763,49 +717,6 @@ int bfio_test_pool_clone(
 		if( bfio_test_malloc_attempts_before_fail != -1 )
 		{
 			bfio_test_malloc_attempts_before_fail = -1;
-
-			if( destination_pool != NULL )
-			{
-				libbfio_pool_free(
-				 &destination_pool,
-				 NULL );
-			}
-		}
-		else
-		{
-			BFIO_TEST_ASSERT_EQUAL_INT(
-			 "result",
-			 result,
-			 -1 );
-
-			BFIO_TEST_ASSERT_IS_NULL(
-			 "destination_pool",
-			 destination_pool );
-
-			BFIO_TEST_ASSERT_IS_NOT_NULL(
-			 "error",
-			 error );
-
-			libcerror_error_free(
-			 &error );
-		}
-	}
-	for( test_number = 0;
-	     test_number < number_of_memset_fail_tests;
-	     test_number++ )
-	{
-		/* Test libbfio_pool_clone with memset failing
-		 */
-		bfio_test_memset_attempts_before_fail = test_number;
-
-		result = libbfio_pool_clone(
-		          &destination_pool,
-		          source_pool,
-		          &error );
-
-		if( bfio_test_memset_attempts_before_fail != -1 )
-		{
-			bfio_test_memset_attempts_before_fail = -1;
 
 			if( destination_pool != NULL )
 			{


### PR DESCRIPTION
The error that's tested against is impossible in any POSIX-compliant
libc -- if it would happen, it'd be a bug in libc rather than the
library's code.  Moreover, the compiler can, and often does, assume
these functions work as specified, and either emit calls to them
or replace them with open-coded stores.

Neither of these functions checks for nor returns any errors; badness
is instead reported via SIGSEGV or SIGBUS.

For these reasons, distributions have disabled memory tests.  Alas,
this means valid tests for functions that actually can fail (like
malloc()) are not run.  Let's drop the bogus ones then.