### PR TITLE
Add basic cmake support

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.27)
+project(libbfio)
+
+add_library(libbfio STATIC
+../libbfio/libbfio_error.c
+../libbfio/libbfio_file.c
+../libbfio/libbfio_file_io_handle.c
+../libbfio/libbfio_file_pool.c
+../libbfio/libbfio_file_range.c
+../libbfio/libbfio_file_range_io_handle.c
+../libbfio/libbfio_handle.c
+../libbfio/libbfio_memory_range.c
+../libbfio/libbfio_memory_range_io_handle.c
+../libbfio/libbfio_pool.c
+../libbfio/libbfio_support.c
+../libbfio/libbfio_system_string.c)
+
+target_include_directories(libbfio PRIVATE 
+../include
+../include/libbfio
+../common
+../../libcerror/include
+../../libcdata/include
+../../libcdata/include/libcdata
+../../libcfile/include
+../../libclocale/include
+../../libcpath/include
+../../libcthreads/include
+../../libuna/include)


### PR DESCRIPTION
Please check if you can accept my pull request. It adds basic cmake compilation support for libbfio. I have tested it with Microsoft Visual Studio, but the most import other compilers (gcc, clang) should work as well.